### PR TITLE
Fix CharacterNode scene path

### DIFF
--- a/scripts/CharacterNode.cs
+++ b/scripts/CharacterNode.cs
@@ -48,7 +48,7 @@ public partial class CharacterNode : Node2D
     
     public static CharacterNode Create()
     {
-        var scene = GD.Load<PackedScene>("res://Scripts/battlesystem/CharacterNode.tscn");
+        var scene = GD.Load<PackedScene>("res://scenes/CharacterNode.tscn");
         var node = scene.Instantiate<CharacterNode>();
         return node;
     }


### PR DESCRIPTION
## Summary
- fix wrong path to `CharacterNode.tscn`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c332b5b7883328bbf2e77986783be