### PR TITLE
Fix variable name typos

### DIFF
--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -7,11 +7,11 @@ public partial class MapRoot : Node2D
     [Export] public int width = 100;
     [Export] public int height = 60;
 
-    TileMapLayer viusal, logic, fog, overlay;
+    TileMapLayer visual, logic, fog, overlay;
 
     public override void _Ready()
     {
-        viusal = GetNode<TileMapLayer>("%TileMap_Visual");
+        visual = GetNode<TileMapLayer>("%TileMap_Visual");
         // logic = GetNode<TileMapLayer>("%TileMap_Logic");
         // fog = GetNode<TileMapLayer>("%TileMap_Fog");
         overlay = GetNode<TileMapLayer>("%TileMap_Overlay");
@@ -19,23 +19,23 @@ public partial class MapRoot : Node2D
         GenerateTerrain();
     }
 
-    Vector2I lasttyleundermousecoordinates;
+    Vector2I lastTileUnderMouseCoordinates;
 
     public override void _UnhandledInput(InputEvent @event)
     {
         if (@event is InputEventMouseMotion ev)
         {
             var tile_coords = overlay.LocalToMap(overlay.ToLocal(ev.GlobalPosition));
-            if (lasttyleundermousecoordinates != tile_coords && usedtiles.Contains(tile_coords))
+            if (lastTileUnderMouseCoordinates != tile_coords && usedtiles.Contains(tile_coords))
             {
-                overlay.SetCell(lasttyleundermousecoordinates, 0, new Vector2I(0, 0));
-                lasttyleundermousecoordinates = tile_coords;
+                overlay.SetCell(lastTileUnderMouseCoordinates, 0, new Vector2I(0, 0));
+                lastTileUnderMouseCoordinates = tile_coords;
                 overlay.SetCell(tile_coords, 0, new Vector2I(2, 0));
             }
-            else if (lasttyleundermousecoordinates != tile_coords && lasttyleundermousecoordinates != Vector2I.Zero)
+            else if (lastTileUnderMouseCoordinates != tile_coords && lastTileUnderMouseCoordinates != Vector2I.Zero)
             {
-                overlay.SetCell(lasttyleundermousecoordinates, 0, new Vector2I(0, 0));
-                lasttyleundermousecoordinates = Vector2I.Zero;
+                overlay.SetCell(lastTileUnderMouseCoordinates, 0, new Vector2I(0, 0));
+                lastTileUnderMouseCoordinates = Vector2I.Zero;
             }
         }
     }
@@ -44,7 +44,7 @@ public partial class MapRoot : Node2D
 
     public void GenerateTerrain()
     {
-        viusal.Clear();
+        visual.Clear();
         // logic.Clear();
         // fog.Clear();
         // overlay.Clear();
@@ -55,7 +55,7 @@ public partial class MapRoot : Node2D
             for (int y = 0; y < height; y++)
             {
                 var coords = new Vector2I(x, y);
-                viusal.SetCell(coords, 0, new Vector2I(2, 2));
+                visual.SetCell(coords, 0, new Vector2I(2, 2));
                 overlay.SetCell(coords, 0, new Vector2I(0, 0));
                 usedtiles.Add(coords);
             }


### PR DESCRIPTION
## Summary
- rename `viusal` field to `visual`
- rename `lasttyleundermousecoordinates` to `lastTileUnderMouseCoordinates`

## Testing
- `dotnet build Zonengenerator_Prototyp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3329c2c48332bec93436f575c5f3