### PR TITLE
Fix _Ready override in MapController

### DIFF
--- a/scripts/MapController.cs
+++ b/scripts/MapController.cs
@@ -13,7 +13,7 @@ public partial class MapController : Node
 
     [Export] public MapGenerator Generator;
 
-    public void _Ready()
+    public override void _Ready()
     {
         var mapData = Generator.Generate();
 


### PR DESCRIPTION
## Summary
- override Node's `_Ready` method in `MapController`

## Testing
- `dotnet --version` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3325f1048332a072591b695636c0