### PR TITLE
Add irregular hex map generation

### DIFF
--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -6,6 +6,7 @@ public partial class MapRoot : Node2D
 {
     [Export] public int width = 100;
     [Export] public int height = 60;
+    [Export] public MapGenerator? Generator;
 
     TileMapLayer visual, logic, fog, overlay;
 
@@ -50,15 +51,26 @@ public partial class MapRoot : Node2D
         // overlay.Clear();
 
         // Generate terrain here
-        for (int x = 0; x < width; x++)
+        IEnumerable<Vector2I> axialCoords;
+        if (Generator != null)
         {
-            for (int y = 0; y < height; y++)
-            {
-                var coords = new Vector2I(x, y);
-                visual.SetCell(coords, 0, new Vector2I(2, 2));
-                overlay.SetCell(coords, 0, new Vector2I(0, 0));
-                usedtiles.Add(coords);
-            }
+            axialCoords = Generator.GenerateShape();
+        }
+        else
+        {
+            List<Vector2I> temp = new();
+            for (int x = 0; x < width; x++)
+                for (int y = 0; y < height; y++)
+                    temp.Add(HexUtils.OffsetToAxial(new Vector2I(x, y)));
+            axialCoords = temp;
+        }
+
+        foreach (var axial in axialCoords)
+        {
+            var coords = HexUtils.AxialToOffset(axial);
+            visual.SetCell(coords, 0, new Vector2I(2, 2));
+            overlay.SetCell(coords, 0, new Vector2I(0, 0));
+            usedtiles.Add(coords);
         }
     }
 

--- a/scripts/Mapgenerator.cs
+++ b/scripts/Mapgenerator.cs
@@ -10,12 +10,20 @@ public partial class MapGenerator : Node
     public int Height = 20;
     public int Seed = 12345;
 
-    public Dictionary<Vector2I, Enums.ZoneType> Generate()
+    /// <summary>
+    /// Creates an irregular collection of axial coordinates representing
+    /// the playable map area. The same seed always returns the same shape.
+    /// </summary>
+    public List<Vector2I> GenerateShape()
     {
         RandomNumberGenerator rng = new RandomNumberGenerator();
         rng.Seed = (ulong)Seed;
 
-        Dictionary<Vector2I, Enums.ZoneType> mapData = new Dictionary<Vector2I, Enums.ZoneType>();
+        List<Vector2I> shape = new List<Vector2I>();
+
+        Vector2I centerOffset = new Vector2I(Width / 2, Height / 2);
+        Vector2I centerAxial = HexUtils.OffsetToAxial(centerOffset);
+        float baseRadius = Math.Min(Width, Height) / 2f;
 
         for (int x = 0; x < Width; x++)
         {
@@ -24,23 +32,46 @@ public partial class MapGenerator : Node
                 Vector2I offset = new Vector2I(x, y);
                 Vector2I axial = HexUtils.OffsetToAxial(offset);
 
-                float roll = rng.Randf();
-                Enums.ZoneType type = roll switch
+                float radiusVariation = rng.RandfRange(-2f, 2f);
+                if (HexUtils.Distance(centerAxial, axial) <= baseRadius + radiusVariation)
                 {
-                    < 0.7f => Enums.ZoneType.Safe,
-                    < 0.9f => Enums.ZoneType.Dangerous,
-                    _ => Enums.ZoneType.Unpassable,
-                };
-
-                mapData[axial] = type;
+                    shape.Add(axial);
+                }
             }
         }
 
+        return shape;
+    }
+
+    public Dictionary<Vector2I, Enums.ZoneType> Generate()
+    {
+        RandomNumberGenerator rng = new RandomNumberGenerator();
+        rng.Seed = (ulong)Seed;
+
+        Dictionary<Vector2I, Enums.ZoneType> mapData = new Dictionary<Vector2I, Enums.ZoneType>();
+
+        var shape = GenerateShape();
+
+        foreach (var axial in shape)
+        {
+            float roll = rng.Randf();
+            Enums.ZoneType type = roll switch
+            {
+                < 0.7f => Enums.ZoneType.Safe,
+                < 0.9f => Enums.ZoneType.Dangerous,
+                _ => Enums.ZoneType.Unpassable,
+            };
+
+            mapData[axial] = type;
+        }
+
         // Beispiel: Übergang nach Norden erzwingen
+        var shapeSet = new HashSet<Vector2I>(shape);
         for (int i = 0; i < Width; i++)
         {
             var pos = HexUtils.OffsetToAxial(new Vector2I(i, 0));
-            mapData[pos] = Enums.ZoneType.Safe; // oder ein spezieller Übergangstyp
+            if (shapeSet.Contains(pos))
+                mapData[pos] = Enums.ZoneType.Safe; // oder ein spezieller Übergangstyp
         }
 
         return mapData;


### PR DESCRIPTION
## Summary
- generate a variable map outline in `MapGenerator`
- only iterate map hexes within that outline
- draw overlay using the generated shape in `MapRoot`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3ade78048332b263b4f253db0ce7