### PR TITLE
Add deterministic location placement

### DIFF
--- a/scripts/LocationInfo.cs
+++ b/scripts/LocationInfo.cs
@@ -1,0 +1,24 @@
+using Godot;
+using System;
+
+public enum DirectionHint
+{
+    NorthWest,
+    NorthEast,
+    SouthWest,
+    SouthEast
+}
+
+public class LocationInfo
+{
+    public string Name { get; set; }
+    public DirectionHint Hint { get; set; }
+    public Vector2I Coordinates { get; set; }
+
+    public LocationInfo(string name, DirectionHint hint)
+    {
+        Name = name;
+        Hint = hint;
+        Coordinates = Vector2I.Zero;
+    }
+}


### PR DESCRIPTION
## Summary
- add `LocationInfo` with directional hint to track custom locations
- implement `MapGenerator.PlaceLocations` to deterministically place locations within quadrants

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3ef13948833293717fada0cb5264