### PR TITLE
Add tile entered event

### DIFF
--- a/scripts/CharacterNode.cs
+++ b/scripts/CharacterNode.cs
@@ -89,6 +89,7 @@ public partial class CharacterNode : Node2D
         {
             Position = _mapRoot.GetTileCenter(mapCoords);
             _mapRoot.UpdateFog(mapCoords, SightRadius);
+            _mapRoot.NotifyTileEntered(mapCoords);
         }
     }
 

--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -11,6 +11,8 @@ public partial class MapRoot : Node2D
     TileMapLayer visual, logic, fog, overlay;
     Dictionary<Vector2I, Enums.ZoneType> zoneData = new();
 
+    public event Action<Vector2I>? OnTileEntered;
+
     public override void _Ready()
     {
         visual = GetNode<TileMapLayer>("%TileMap_Visual");
@@ -153,7 +155,13 @@ public partial class MapRoot : Node2D
             tween.TweenProperty(character, "position", target, 0.2f);
             await ToSignal(tween, "finished");
             character.MoveTo(offset);
+            OnTileEntered?.Invoke(offset);
         }
+    }
+
+    public void NotifyTileEntered(Vector2I tile)
+    {
+        OnTileEntered?.Invoke(tile);
     }
 
 


### PR DESCRIPTION
## Summary
- add `OnTileEntered` event to `MapRoot`
- notify listeners when a character moves to a tile
- expose helper `NotifyTileEntered` for other scripts
- trigger the event from both map animation and character movement

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4895a36083329c8328fcf08dbf7c