### PR TITLE
Add grid menu and map handlers

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -29,12 +29,19 @@ theme_override_constants/margin_top = 50
 theme_override_constants/margin_right = 50
 theme_override_constants/margin_bottom = 50
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
+[node name="GridContainer" type="GridContainer" parent="PanelContainer/MarginContainer"]
 layout_mode = 2
+columns = 3
 
-[node name="btnKampf1" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Start"
+[node name="ButtonSmall" type="Button" parent="PanelContainer/MarginContainer/GridContainer"]
+text = "Small map"
 
-[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/btnKampf1" to="." method="_on_btn_kampf_1_pressed"]
+[node name="ButtonMedium" type="Button" parent="PanelContainer/MarginContainer/GridContainer"]
+text = "Medium map"
+
+[node name="ButtonLarge" type="Button" parent="PanelContainer/MarginContainer/GridContainer"]
+text = "Large map"
+
+[connection signal="pressed" from="PanelContainer/MarginContainer/GridContainer/ButtonSmall" to="." method="_on_small_map_pressed"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/GridContainer/ButtonMedium" to="." method="_on_medium_map_pressed"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/GridContainer/ButtonLarge" to="." method="_on_large_map_pressed"]

--- a/scripts/Game.cs
+++ b/scripts/Game.cs
@@ -66,15 +66,38 @@ public partial class Game : Control
 
     public override void _Ready()
     {
-        // // Handles only the first child
-         previousContent = MainContent.GetChildCount() > 0 ? MainContent.GetChild<Control>(0) : null;
+        // Handles only the first child
+        previousContent = MainContent.GetChildCount() > 0 ? MainContent.GetChild<Control>(0) : null;
 
-    }    
+    }
 
-    internal void _on_btn_kampf_1_pressed()
+    private void DisplayMap(MapRoot map)
     {
-        
+        foreach (Node child in MainContent.GetChildren())
+        {
+            MainContent.RemoveChild(child);
+            child.QueueFree();
+        }
 
+        MainContent.AddChild(map);
+    }
+
+    private void _on_small_map_pressed()
+    {
+        var map = CreateSmallMap();
+        DisplayMap(map);
+    }
+
+    private void _on_medium_map_pressed()
+    {
+        var map = CreateMediumMap();
+        DisplayMap(map);
+    }
+
+    private void _on_large_map_pressed()
+    {
+        var map = CreateLargeMap();
+        DisplayMap(map);
     }
 
 


### PR DESCRIPTION
## Summary
- replace VBoxContainer with GridContainer in the game scene
- add three buttons to pick a map size
- wire up button signals to new handlers
- implement handlers to create and display generated maps

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5b1c90d48332befa4bc33f0331a6