### PR TITLE
Add camera scrolling to map

### DIFF
--- a/scenes/map_root.tscn
+++ b/scenes/map_root.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="TileSet" uid="uid://dkheur6etnl5a" path="res://tilesets/logic_tile_set.tres" id="2_155yj"]
 [ext_resource type="TileSet" uid="uid://h4m3bkbos37e" path="res://tilesets/fog_tile_set.tres" id="3_2rd5c"]
 [ext_resource type="TileSet" uid="uid://d3241dpbnefp0" path="res://tilesets/overlay_tile_set.tres" id="4_22de6"]
+[ext_resource type="Script" uid="uid://x9v4tb6k3u8y" path="res://scripts/MapCameraController.cs" id="5_cam"]
 
 [node name="MapRoot" type="Node2D"]
 script = ExtResource("1_155yj")
@@ -27,3 +28,6 @@ tile_set = ExtResource("3_2rd5c")
 [node name="TileMap_Overlay" type="TileMapLayer" parent="."]
 unique_name_in_owner = true
 tile_set = ExtResource("4_22de6")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+script = ExtResource("5_cam")

--- a/scripts/Game.cs
+++ b/scripts/Game.cs
@@ -85,6 +85,9 @@ public partial class Game : Control
         mapContainerNode.AddChild(map);
         map.Visible = true;
         map.Scale = Vector2.One;
+        var cam = map.GetNodeOrNull<Camera2D>("Camera2D");
+        if (cam != null)
+            cam.MakeCurrent();
     }
 
     private void _on_small_map_pressed()

--- a/scripts/MapCameraController.cs
+++ b/scripts/MapCameraController.cs
@@ -1,0 +1,67 @@
+using Godot;
+using System;
+
+public partial class MapCameraController : Camera2D
+{
+    [Export] public int ScrollBorder = 20;
+    [Export] public float ScrollSpeed = 400f;
+    [Export] public MapRoot? Map;
+
+    public override void _Ready()
+    {
+        if (Map == null)
+            Map = GetParent<MapRoot>();
+    }
+
+    public override void _Process(double delta)
+    {
+        if (Map == null)
+            return;
+
+        Vector2 viewportSize = GetViewportRect().Size;
+        Vector2 mousePos = GetViewport().GetMousePosition();
+        Vector2 dir = Vector2.Zero;
+
+        if (mousePos.X < ScrollBorder)
+            dir.X -= 1;
+        else if (mousePos.X > viewportSize.X - ScrollBorder)
+            dir.X += 1;
+
+        if (mousePos.Y < ScrollBorder)
+            dir.Y -= 1;
+        else if (mousePos.Y > viewportSize.Y - ScrollBorder)
+            dir.Y += 1;
+
+        if (dir != Vector2.Zero)
+        {
+            Position += dir.Normalized() * ScrollSpeed * (float)delta;
+            ClampToMap(viewportSize);
+        }
+    }
+
+    private void ClampToMap(Vector2 viewportSize)
+    {
+        if (Map == null)
+            return;
+
+        int mapWidth = Map.Generator != null ? Map.Generator.Width : Map.width;
+        int mapHeight = Map.Generator != null ? Map.Generator.Height : Map.height;
+        var tilemap = Map.GetNode<TileMapLayer>("%TileMap_Visual");
+        Vector2 tileSize = tilemap.TileSet.TileSize;
+
+        Vector2 mapSize = new Vector2(mapWidth * tileSize.X, mapHeight * tileSize.Y);
+
+        float halfW = viewportSize.X / 2f;
+        float halfH = viewportSize.Y / 2f;
+
+        float minX = halfW;
+        float minY = halfH;
+        float maxX = Math.Max(minX, mapSize.X - halfW);
+        float maxY = Math.Max(minY, mapSize.Y - halfH);
+
+        Position = new Vector2(
+            Mathf.Clamp(Position.X, minX, maxX),
+            Mathf.Clamp(Position.Y, minY, maxY)
+        );
+    }
+}

--- a/scripts/MapCameraController.cs.uid
+++ b/scripts/MapCameraController.cs.uid
@@ -1,0 +1,1 @@
+uid://x9v4tb6k3u8y


### PR DESCRIPTION
## Summary
- add `MapCameraController` for scrolling when mouse is near viewport edges
- add a `Camera2D` to `map_root.tscn` and attach the controller
- activate the camera when the map is shown

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c64d41a9483328d5f416386c12e70