### PR TITLE
Spawn character on map load

### DIFF
--- a/scripts/MapCameraController.cs
+++ b/scripts/MapCameraController.cs
@@ -12,6 +12,20 @@ public partial class MapCameraController : Camera2D
     private CharacterNode? _character;
     private Button? _recenterButton;
 
+    public void SetCharacter(CharacterNode character)
+    {
+        _character = character;
+        CharacterPath = GetPathTo(character);
+    }
+
+    public void CenterOnCharacter()
+    {
+        if (_character == null)
+            return;
+        Position = _character.GlobalPosition;
+        ClampToMap(GetViewportRect().Size);
+    }
+
     public override void _Ready()
     {
         if (Map == null)

--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 public partial class MapRoot : Node2D
 {
@@ -32,6 +33,22 @@ public partial class MapRoot : Node2D
         OnTransitionEntered += destination => GD.Print($"Load map: {destination}");
 
         GenerateTerrain();
+
+        if (transitions.Count > 0)
+        {
+            var entryTile = transitions.Keys.First();
+            var character = CharacterNode.Create();
+            character.Name = "CharacterNode";
+            AddChild(character);
+            character.CallDeferred(nameof(CharacterNode.MoveTo), entryTile);
+
+            var cam = GetNodeOrNull<MapCameraController>("Camera2D");
+            if (cam != null)
+            {
+                cam.SetCharacter(character);
+                cam.CallDeferred(nameof(MapCameraController.CenterOnCharacter));
+            }
+        }
     }
 
     Vector2I lastTileUnderMouseCoordinates;


### PR DESCRIPTION
## Summary
- instantiate a character after generating the map and place it at the first transition tile
- let the camera controller handle this character and recenter on it
- expose methods on `MapCameraController` to set and center on a character

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2770eae48332bdacc5803d50b785