### PR TITLE
Add mouse button handling for MapRoot

### DIFF
--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -22,6 +22,7 @@ public partial class MapRoot : Node2D
 
     public event Action<Vector2I>? OnTileEntered;
     public event Action<string>? OnTransitionEntered;
+    public event Action<Vector2I>? OnTileRightClicked;
 
     public override void _Ready()
     {
@@ -95,6 +96,30 @@ public partial class MapRoot : Node2D
             else
             {
                 ClearPreview();
+            }
+        }
+        else if (@event is InputEventMouseButton mouse && mouse.Pressed)
+        {
+            var tileCoords = overlay.LocalToMap(overlay.ToLocal(mouse.GlobalPosition));
+
+            if (!usedtiles.Contains(tileCoords))
+                return;
+
+            if (mouse.ButtonIndex == MouseButton.Left && mouse.DoubleClick)
+            {
+                var character = GetNodeOrNull<CharacterNode>("CharacterNode");
+                if (character == null)
+                    return;
+
+                var startOffset = visual.LocalToMap(character.Position);
+                var path = ComputePath(startOffset, tileCoords);
+
+                if (path.Count > 0)
+                    _ = AnimateCharacterAlongPath(character, path);
+            }
+            else if (mouse.ButtonIndex == MouseButton.Right)
+            {
+                OnTileRightClicked?.Invoke(tileCoords);
             }
         }
     }


### PR DESCRIPTION
## Summary
- respond to left/right clicks in `MapRoot._UnhandledInput`
- fire new `OnTileRightClicked` event
- animate character on double-click moves

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d293a76488332b73b9a3177765628