### PR TITLE
Add location discovery events

### DIFF
--- a/scripts/Game.cs
+++ b/scripts/Game.cs
@@ -24,6 +24,7 @@ public partial class Game : Control
         generator.PlaceLocations(mapData, locations);
 
         mapRoot.Generator = generator;
+        mapRoot.Locations = locations;
 
         return mapRoot;
     }


### PR DESCRIPTION
## Summary
- accept list of locations when constructing MapRoot
- store location data and reveal markers when explored
- emit `OnLocationDiscovered` on first discovery

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d32918d848332a9cb67a53f3351c1