### PR TITLE
Expose MapRoot events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # zonengenerator_prototyp
+
+## MapRoot Events
+
+`MapRoot` exposes several events that allow game logic to react to player
+interactions:
+
+* `OnTileEntered(Vector2I tile)` - fired when the character moves onto a tile.
+* `OnTileRightClicked(Vector2I tile)` - fired when a tile is right-clicked.
+* `OnLocationDiscovered(LocationInfo info)` - fired the first time a location
+  becomes visible.
+
+See `Game.cs` for a simple subscription example.

--- a/scripts/Game.cs
+++ b/scripts/Game.cs
@@ -83,6 +83,10 @@ public partial class Game : Control
         MapContainerNode.AddChild(map);
         map.Visible = true;
         map.Scale = Vector2.One;
+
+        // Example event subscriptions
+        map.OnLocationDiscovered += info =>
+            GD.Print($"Location discovered: {info.Name}");
         var cam = map.GetNodeOrNull<MapCameraController>("Camera2D");
         if (cam != null)
         {

--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -29,9 +29,25 @@ public partial class MapRoot : Node2D
     Vector2I? lastVisitedTile = null;
     public float DistanceTravelledKm => distanceTravelledKm;
 
+    /// <summary>
+    /// Fired whenever the character steps onto a new tile.
+    /// </summary>
     public event Action<Vector2I>? OnTileEntered;
+
+    /// <summary>
+    /// Fired when a transition tile is entered. The string parameter contains
+    /// the destination map name.
+    /// </summary>
     public event Action<string>? OnTransitionEntered;
+
+    /// <summary>
+    /// Fired when the user right-clicks a tile on the map.
+    /// </summary>
     public event Action<Vector2I>? OnTileRightClicked;
+
+    /// <summary>
+    /// Fired the first time a location becomes visible to the player.
+    /// </summary>
     public event Action<LocationInfo>? OnLocationDiscovered;
 
     public override void _Ready()


### PR DESCRIPTION
## Summary
- add README event documentation
- document MapRoot events with XML comments
- log discovered locations from Game.cs as an example event subscription

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d38424ef8833283fc121733acf092