### PR TITLE
Fix tile duplication when regenerating map

### DIFF
--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -160,6 +160,7 @@ public partial class MapRoot : Node2D
 
     public void GenerateTerrain()
     {
+        usedtiles.Clear();
         visual.Clear();
         logic.Clear();
         fog.Clear();


### PR DESCRIPTION
## Summary
- clear `usedtiles` at the start of `GenerateTerrain` to avoid duplicates

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d464efaf88332ac8c3413522667ee