### PR TITLE
Fix move sync for CharacterNode

### DIFF
--- a/scripts/CharacterNode.cs
+++ b/scripts/CharacterNode.cs
@@ -85,6 +85,7 @@ public partial class CharacterNode : Node2D
 
     public void MoveTo(Vector2I mapCoords)
     {
+        _mapCoords = mapCoords;
         if (_mapRoot != null)
         {
             Position = _mapRoot.GetTileCenter(mapCoords);


### PR DESCRIPTION
## Summary
- keep CharacterNode's internal coordinates up to date

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d483123b083329cd46049697500a3