### PR TITLE
Remove obsolete MapController uid

### DIFF
--- a/scripts/MapController.cs.uid
+++ b/scripts/MapController.cs.uid
@@ -1,1 +1,0 @@
-uid://m6jnup3j0wml


### PR DESCRIPTION
## Summary
- remove leftover `MapController.cs.uid` file

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5793197c833290ed8f7939ea5068