### PR TITLE
[Auto] Korrekte Position in Hex-Feld

### DIFF
--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -333,7 +333,9 @@ public partial class MapRoot : Node2D
     /// <param name="tile">Tile coordinates.</param>
     public Vector2 GetTileCenter(Vector2I tile)
     {
-        return visual.MapToLocal(tile) + visual.TileSet.TileSize / 2;
+        // MapToLocal() already returns the center for hex maps. Adding half the
+        // tile size would shift the result down by one row.
+        return visual.MapToLocal(tile);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- korrigiere GetTileCenter in MapRoot damit die Mitte eines Hexfeldes korrekt berechnet wird

## Testing
- `dotnet build`
- `dotnet test --logger:trx`
- `./Godot_v4.4.1-stable_mono_linux_x86_64/Godot_v4.4.1-stable_mono_linux.x86_64 --headless --path . --main-scene scenes/game.tscn --quit -v`

------
https://chatgpt.com/codex/tasks/task_e_685dad8aa9288332a66cb07ec79930a1