### PR TITLE
[ChatGPT] Fix fog tile indexing

### DIFF
--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -318,7 +318,7 @@ public partial class MapRoot : Node2D
             }
             else if (discoveredTiles.Contains(tile))
             {
-                fog.SetCell(tile, 0, new Vector2I(4, 0));
+                fog.SetCell(tile, 0, new Vector2I(3, 0));
             }
             else
             {

--- a/tilesets/fog_tile_set.tres
+++ b/tilesets/fog_tile_set.tres
@@ -1,4 +1,4 @@
-[gd_resource type="TileSet" load_steps=8 format=3 uid="uid://h4m3bkbos37e"]
+[gd_resource type="TileSet" load_steps=9 format=3 uid="uid://h4m3bkbos37e"]
 
 [ext_resource type="Shader" path="res://assets/textures/shaders/fog_shader.gdshader" id="2_shader"]
 [ext_resource type="Texture2D" uid="uid://bwkygyyqh8fx3" path="res://assets/textures/Terrain 1 - Flat - No Outline - 128x128.png" id="2_y4xh8"]
@@ -19,6 +19,10 @@ shader_parameter/alpha = 0.5
 shader = ExtResource("2_shader")
 shader_parameter/alpha = 0.25
 
+[sub_resource type="ShaderMaterial" id="FogMaterial_4"]
+shader = ExtResource("2_shader")
+shader_parameter/alpha = 0.0
+
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_0"]
 texture = ExtResource("2_y4xh8")
 texture_region_size = Vector2i(128, 128)
@@ -30,14 +34,18 @@ texture_region_size = Vector2i(128, 128)
 2:0/0/material = SubResource("FogMaterial_2")
 3:0/0 = 0
 3:0/0/material = SubResource("FogMaterial_3")
+4:0/0 = 0
+4:0/0/material = SubResource("FogMaterial_4")
 0:1/0 = 0
 1:1/0 = 0
 2:1/0 = 0
 3:1/0 = 0
+4:1/0 = 0
 0:2/0 = 0
 1:2/0 = 0
 2:2/0 = 0
 3:2/0 = 0
+4:2/0 = 0
 
 [resource]
 tile_shape = 3


### PR DESCRIPTION
## Summary
- add fifth tile for transparent fog
- use tile index 3 for discovered fog

## Testing
- `dotnet build`
- `./Godot_v4.4.1-stable_mono_linux.x86_64 --headless --path . --main-scene scenes/game.tscn --quit -v`


------
https://chatgpt.com/codex/tasks/task_e_685db9d400f883329a2bae12d48bc083