### PR TITLE
[ChatGPT] Add water zone handling

### DIFF
--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -380,7 +380,9 @@ public partial class MapRoot : Node2D
         var targetAxial = HexUtils.OffsetToAxial(targetOffset);
         return Pathfinder.FindPath(startAxial, targetAxial, ax =>
         {
-            return zoneData.ContainsKey(ax) && zoneData[ax] != Enums.ZoneType.Unpassable;
+            return zoneData.ContainsKey(ax)
+                && zoneData[ax] != Enums.ZoneType.Unpassable
+                && zoneData[ax] != Enums.ZoneType.Water;
         });
     }
 

--- a/scripts/Mapgenerator.cs
+++ b/scripts/Mapgenerator.cs
@@ -82,8 +82,9 @@ public partial class MapGenerator : Node
             float roll = rng.Randf();
             Enums.ZoneType type = roll switch
             {
-                < 0.7f => Enums.ZoneType.Safe,
-                < 0.9f => Enums.ZoneType.Dangerous,
+                < 0.6f => Enums.ZoneType.Safe,
+                < 0.75f => Enums.ZoneType.Dangerous,
+                < 0.9f => Enums.ZoneType.Water,
                 _ => Enums.ZoneType.Unpassable,
             };
 
@@ -109,7 +110,7 @@ public partial class MapGenerator : Node
 
         foreach (var kvp in mapData)
         {
-            if (kvp.Value == Enums.ZoneType.Unpassable)
+            if (kvp.Value == Enums.ZoneType.Unpassable || kvp.Value == Enums.ZoneType.Water)
                 continue;
 
             var offset = HexUtils.AxialToOffset(kvp.Key);
@@ -151,7 +152,7 @@ public partial class MapGenerator : Node
 
             foreach (var kvp in mapData)
             {
-                if (kvp.Value == Enums.ZoneType.Unpassable)
+                if (kvp.Value == Enums.ZoneType.Unpassable || kvp.Value == Enums.ZoneType.Water)
                     continue;
 
                 Vector2I offset = HexUtils.AxialToOffset(kvp.Key);


### PR DESCRIPTION
## Summary
- expand map generator to produce `Water` tiles
- exclude water from transitions and location placement
- prevent pathfinding through water

## Testing
- `dotnet build`
- `./Godot_v4.4.1-stable_mono_linux.x86_64/Godot_v4.4.1-stable_mono_linux.x86_64 --headless --path . --main-scene scenes/game.tscn --quit -v`

------
https://chatgpt.com/codex/tasks/task_e_685dbf22071c833296e4e596560b36b4