### PR TITLE
[ChatGPT] Nebula border around map

### DIFF
--- a/assets/textures/shaders/white_nebula.gdshader
+++ b/assets/textures/shaders/white_nebula.gdshader
@@ -1,0 +1,36 @@
+shader_type canvas_item;
+render_mode unshaded, blend_premul_alpha;
+
+// Was?  Weißer Nebel für den Kartenrand.
+// Wie?  Zwei Rauschlayer werden animiert und gemischt.
+// Warum?  Damit beim Scrollen kein leerer Hintergrund sichtbar wird.
+
+uniform float scale = 4.0;   // Dichte des Musters
+uniform float speed = 0.1;   // Animationsgeschwindigkeit
+uniform float alpha = 0.6;   // Deckkraft
+
+float rand(vec2 co) {
+    return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+float noise2d(vec2 st) {
+    vec2 i = floor(st);
+    vec2 f = fract(st);
+    float a = rand(i);
+    float b = rand(i + vec2(1.0, 0.0));
+    float c = rand(i + vec2(0.0, 1.0));
+    float d = rand(i + vec2(1.0, 1.0));
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(a, b, u.x) +
+           (c - a) * u.y * (1.0 - u.x) +
+           (d - b) * u.x * u.y;
+}
+
+void fragment() {
+    vec2 uv = UV * scale + vec2(TIME * speed, TIME * speed * 0.5);
+    float n1 = noise2d(uv);
+    float n2 = noise2d(uv * 2.0 + 10.0);
+    float n = mix(n1, n2, 0.5);
+    float intensity = pow(n, 1.5);
+    COLOR = vec4(vec3(intensity), intensity * alpha);
+}

--- a/scenes/map_root.tscn
+++ b/scenes/map_root.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dbkg6ppdfkoqc"]
+[gd_scene load_steps=8 format=3 uid="uid://dbkg6ppdfkoqc"]
 
 [ext_resource type="Script" uid="uid://b8mqpmxiplno7" path="res://scripts/MapRoot.cs" id="1_155yj"]
 [ext_resource type="TileSet" uid="uid://iwqi2v2e1p7l" path="res://tilesets/visual_tile_set.tres" id="1_yh41v"]
@@ -6,11 +6,17 @@
 [ext_resource type="TileSet" uid="uid://h4m3bkbos37e" path="res://tilesets/fog_tile_set.tres" id="3_2rd5c"]
 [ext_resource type="TileSet" uid="uid://d3241dpbnefp0" path="res://tilesets/overlay_tile_set.tres" id="4_22de6"]
 [ext_resource type="Script" uid="uid://yav4tb6k3u8y" path="res://scripts/MapCameraController.cs" id="5_cam"]
+[ext_resource type="TileSet" path="res://tilesets/nebula_tile_set.tres" id="6_nebula"]
 
 [node name="MapRoot" type="Node2D"]
 script = ExtResource("1_155yj")
 width = 10
 height = 10
+
+[node name="TileMap_Nebula" type="TileMapLayer" parent="."]
+unique_name_in_owner = true
+tile_set = ExtResource("6_nebula")
+z_index = -1
 
 [node name="TileMap_Visual" type="TileMapLayer" parent="."]
 unique_name_in_owner = true

--- a/scripts/MapCameraController.cs
+++ b/scripts/MapCameraController.cs
@@ -177,8 +177,8 @@ public partial class MapCameraController : Camera2D
         if (Map == null)
             return;
 
-        int mapWidth = Map.Generator != null ? Map.Generator.HexagonsWidth : Map.width;
-        int mapHeight = Map.Generator != null ? Map.Generator.HexagonsHeight : Map.height;
+        int mapWidth = (Map.Generator != null ? Map.Generator.HexagonsWidth : Map.width) + Map.NebulaRingWidth * 2;
+        int mapHeight = (Map.Generator != null ? Map.Generator.HexagonsHeight : Map.height) + Map.NebulaRingWidth * 2;
         var tilemap = Map.GetNode<TileMapLayer>("%TileMap_Visual");
         Vector2 tileSize = tilemap.TileSet.TileSize;
 

--- a/scripts/MapRoot.cs
+++ b/scripts/MapRoot.cs
@@ -66,7 +66,11 @@ public partial class MapRoot : Node2D
     /// <summary>Area in square kilometres represented by a tile.</summary>
     public float KmPerHexArea => KmPerHexX * KmPerHexY;
 
-    TileMapLayer visual, logic, fog, overlay;
+    /// <summary>Ring around the map rendered with a nebula shader.</summary>
+    [Export]
+    public int NebulaRingWidth = 10;
+
+    TileMapLayer visual, logic, fog, overlay, nebula;
     Dictionary<Vector2I, Enums.ZoneType> zoneData = new();
     Dictionary<Vector2I, string> transitions = new();
     Dictionary<Vector2I, LocationInfo> locationLookup = new();
@@ -114,6 +118,7 @@ public partial class MapRoot : Node2D
         logic = GetNode<TileMapLayer>("%TileMap_Logic");
         fog = GetNode<TileMapLayer>("%TileMap_Fog");
         overlay = GetNode<TileMapLayer>("%TileMap_Overlay");
+        nebula = GetNode<TileMapLayer>("%TileMap_Nebula");
 
         OnTransitionEntered += destination => GD.Print($"Load map: {destination}");
 
@@ -258,6 +263,7 @@ public partial class MapRoot : Node2D
         logic.Clear();
         fog.Clear();
         overlay.Clear();
+        nebula.Clear();
 
         visitedTiles.Clear();
         discoveredTiles.Clear();
@@ -328,6 +334,8 @@ public partial class MapRoot : Node2D
                 locationLookup[loc.Coordinates] = loc;
             }
         }
+
+        CreateNebulaRing();
     }
 
     /// <summary>
@@ -498,5 +506,22 @@ public partial class MapRoot : Node2D
         }
     }
 
+    /// <summary>
+    /// Creates a surrounding ring of tiles with the nebula shader so that
+    /// camera movement never exposes the default background.
+    /// </summary>
+    private void CreateNebulaRing()
+    {
+        for (int x = -NebulaRingWidth; x < width + NebulaRingWidth; x++)
+        {
+            for (int y = -NebulaRingWidth; y < height + NebulaRingWidth; y++)
+            {
+                if (x >= 0 && y >= 0 && x < width && y < height)
+                    continue;
 
+                nebula.SetCell(new Vector2I(x, y), 0, new Vector2I(0, 0));
+            }
+        }
+    }
 }
+

--- a/tilesets/nebula_tile_set.tres
+++ b/tilesets/nebula_tile_set.tres
@@ -1,0 +1,18 @@
+[gd_resource type="TileSet" load_steps=4 format=3]
+
+[ext_resource type="Texture2D" path="res://assets/textures/Terrain 1 - Flat - No Outline - 128x128.png" id="1_tex"]
+[ext_resource type="Shader" path="res://assets/textures/shaders/white_nebula.gdshader" id="1_shd"]
+
+[sub_resource type="ShaderMaterial" id="NebulaMat"]
+shader = ExtResource("1_shd")
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_neb"]
+texture = ExtResource("1_tex")
+texture_region_size = Vector2i(128, 128)
+0:0/0 = 0
+0:0/0/material = SubResource("NebulaMat")
+
+[resource]
+tile_shape = 3
+tile_size = Vector2i(128, 128)
+sources/0 = SubResource("TileSetAtlasSource_neb")


### PR DESCRIPTION
## Summary
- create `white_nebula.gdshader` for a simple animated nebula effect
- add `nebula_tile_set.tres` and a new TileMap layer
- draw a wide nebula ring around the map in `MapRoot`
- clamp the camera to include the nebula border

## Testing
- `dotnet build`
- `Godot_v4.4.1-stable_mono_linux_x86_64/Godot_v4.4.1-stable_mono_linux_x86_64/Godot_v4.4.1-stable_mono_linux.x86_64 --headless --path . --main-scene scenes/game.tscn --quit -v`

------
https://chatgpt.com/codex/tasks/task_e_685ea60949b08332aaebced1ec85d160