### PR TITLE
[ChatGPT] adjust edge scroll default

### DIFF
--- a/scripts/MapCameraController.cs
+++ b/scripts/MapCameraController.cs
@@ -7,8 +7,8 @@ using System;
 /// </summary>
 public partial class MapCameraController : Camera2D
 {
-    /// <summary>Distance from screen edge that starts scrolling.</summary>
-    [Export] public int ScrollBorder = 20;
+    /// <summary>Size of the edge-scroll activation zone in pixels.</summary>
+    [Export] public int ScrollBorder = 30;
 
     /// <summary>Speed of manual scrolling in pixels per second.</summary>
     [Export] public float ScrollSpeed = 400f;


### PR DESCRIPTION
## Summary
- tweak MapCameraController default scroll border

## Testing
- `dotnet build`
- `./Godot_v4.4.1-stable_mono_linux.x86_64 --headless --path . --main-scene scenes/game.tscn --quit -v`


------
https://chatgpt.com/codex/tasks/task_e_685ea9f09a70833291ebc3326926d42d